### PR TITLE
bump sbt version to 1.0.4 and remove workaround code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ lazy val commonSettings = Seq(
   version := "0.3.5-SNAPSHOT"
 )
 
-sbtVersion in Global := "1.0.0" // must be Global, otherwise ^^ won't change anything
-crossSbtVersions := List("0.13.13", "1.0.0")
+sbtVersion in Global := "1.0.4" // must be Global, otherwise ^^ won't change anything
+crossSbtVersions := List("0.13.13", "1.0.4")
 
 lazy val root = (project in file(".")).
   settings(
@@ -23,12 +23,4 @@ lazy val root = (project in file(".")).
     scmInfo := Some(ScmInfo(url("https://github.com/sbt/sbt-houserules"), "git@github.com:sbt/sbt-houserules.git")),
     bintrayOrganization := Some("sbt"),
     bintrayRepository := "sbt-plugin-releases"
-  )
-
-// WORKAROUND https://github.com/sbt/sbt/issues/3393
-def addSbtPlugin(m: ModuleID) =
-  libraryDependencies += Defaults.sbtPluginExtra(
-    m,
-    (sbtBinaryVersion in pluginCrossBuild).value,
-    (scalaBinaryVersion in update).value
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=1.0.4


### PR DESCRIPTION
sbt/sbt#3393 has been fixed, so the workaround code should no
longer be needed.  the call to `update` in the workaround code
is not dbuild-friendly (since it tries to retrieve dependencies
during dependency extraction, before dbuild has had a chance
to actually build the dependencies), so it's worth removing