### PR TITLE
fix scalacOptions for Scala 2.13

### DIFF
--- a/src/main/scala/sbt/houserules/HouseRulesPlugin.scala
+++ b/src/main/scala/sbt/houserules/HouseRulesPlugin.scala
@@ -21,12 +21,12 @@ object HouseRulesPlugin extends AutoPlugin {
     scalacOptions  += "-language:implicitConversions",
     scalacOptions  += "-Xfuture",
     scalacOptions ++= "-Yinline-warnings".ifScala211Minus.value.toList,
-    scalacOptions  += "-Yno-adapted-args",
+    scalacOptions ++= "-Yno-adapted-args".ifScala212Minus.value.toList,
     scalacOptions  += "-Ywarn-dead-code",
     scalacOptions  += "-Ywarn-numeric-widen",
     scalacOptions  += "-Ywarn-value-discard",
     scalacOptions ++= "-Ywarn-unused".ifScala211Plus.value.toList,
-    scalacOptions ++= "-Ywarn-unused-import".ifScala211Plus.value.toList
+    scalacOptions ++= "-Ywarn-unused-import".ifScala(v => 11 <= v && v <= 12).value
   ) ++ Seq(Compile, Test).flatMap(c =>
     scalacOptions in (c, console) --= Seq("-Ywarn-unused", "-Ywarn-unused-import")
   )
@@ -39,5 +39,6 @@ object HouseRulesPlugin extends AutoPlugin {
     def ifScalaGte(v: Long)         = ifScala(_ >= v)
     def ifScala211Minus             = ifScalaLte(11)
     def ifScala211Plus              = ifScalaGte(11)
+    def ifScala212Minus             = ifScalaLte(12)
   }
 }


### PR DESCRIPTION
"-Yno-adapted-args" and "-Ywarn-unused-import" removed since Scala 2.13

https://github.com/scala/scala/commit/ad25805de5c63084348348aabefdf184927806c2