### PR TITLE
Remove -Ywarn-unused, and add -Xfatal-warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,16 @@ language: scala
 
 jdk:
   - oraclejdk8
+
+script:
+   - sbt test
+
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.3

--- a/src/main/scala/sbt/houserules/HouseRulesPlugin.scala
+++ b/src/main/scala/sbt/houserules/HouseRulesPlugin.scala
@@ -20,15 +20,15 @@ object HouseRulesPlugin extends AutoPlugin {
     scalacOptions  += "-language:higherKinds",
     scalacOptions  += "-language:implicitConversions",
     scalacOptions  += "-Xfuture",
+    scalacOptions ++= "-Xfatal-warnings".ifScala(_ == 12).value.toList,
     scalacOptions ++= "-Yinline-warnings".ifScala211Minus.value.toList,
     scalacOptions ++= "-Yno-adapted-args".ifScala212Minus.value.toList,
     scalacOptions  += "-Ywarn-dead-code",
     scalacOptions  += "-Ywarn-numeric-widen",
     scalacOptions  += "-Ywarn-value-discard",
-    scalacOptions ++= "-Ywarn-unused".ifScala211Plus.value.toList,
     scalacOptions ++= "-Ywarn-unused-import".ifScala(v => 11 <= v && v <= 12).value
   ) ++ Seq(Compile, Test).flatMap(c =>
-    scalacOptions in (c, console) --= Seq("-Ywarn-unused", "-Ywarn-unused-import")
+    scalacOptions in (c, console) --= Seq("-Ywarn-unused-import", "-Xlint")
   )
 
   private def scalaPartV = Def setting (CrossVersion partialVersion scalaVersion.value)


### PR DESCRIPTION
-Ywarn-used has too many false positives especially for contraband generated code.
Since -Xlint already includes most unsed warning, I think it's ok to remove this.
Instead, I'm making the warnings fatal by default.